### PR TITLE
feat(parser): expose findESIIncludeTags for ESI pre-processing

### DIFF
--- a/lib/esi.js
+++ b/lib/esi.js
@@ -23,7 +23,7 @@ function ESI(config) {
         const maxDepthReached = state.currentDepth > maxDepth;
 
         let i = 0;
-        findESIInclueTags(html, options)
+        findESIIncludeTags(html, options)
             .forEach(tag => {
                 const placeholder = '<!-- esi-placeholder-' + i + ' -->';
 
@@ -55,7 +55,7 @@ function ESI(config) {
         return html.includes('<esi:');
     }
 
-    function findESIInclueTags(html) {
+    function findESIIncludeTags(html) {
         const open = '<esi:include';
         const fullClose = '</esi:include>';
         const selfClose = '/>';
@@ -134,7 +134,7 @@ function ESI(config) {
         return '';
     }
 
-    return {process, handleError, logger};
+    return {process, handleError, logger, findESIIncludeTags};
 }
 
 ESI.DataProvider = DataProvider;

--- a/test/e2e-test.js
+++ b/test/e2e-test.js
@@ -542,4 +542,18 @@ describe('ESI processor', () => {
             }
         });
     });
+
+    it('Should provide list of ESI tags with findESIIncludeTags', () => {
+        const esi = ESI();
+
+        const html = `<nav><esi:include src="/nav.html"></esi:include><nav>
+        <main><esi:include src='/main.html'/></main>`;
+
+        const tags = esi.findESIIncludeTags(html);
+
+        assert.equal(tags.length, 2);
+        assert.deepEqual(tags, [
+            `<esi:include src="/nav.html"></esi:include>`, 
+            `<esi:include src='/main.html'/>`]);
+    })
 });


### PR DESCRIPTION
We need to pre-process the ESI tags so that they play nicely with a standard HTML parser, which does not recognize self-closing tags. Instead of rolling our own regex-based ESI parser, we'd like to use `nodesi`. Therefore this change renames `findESIInclueTags` to `findESIIncludeTags` and exposes it as part of the `ESI` API.

see https://github.com/adobe/helix-pipeline/issues/317