### PR TITLE
Decode Entities in URL before passing over to Data Provider

### DIFF
--- a/lib/esi.js
+++ b/lib/esi.js
@@ -3,6 +3,7 @@
 const AllowedHosts = require('./allowed-hosts');
 const DataProvider = require('./data-provider');
 const Logger = require('./logger');
+const { decode } = require('he');
 
 function ESI(config) {
     config = config || {};
@@ -112,6 +113,7 @@ function ESI(config) {
     const getUnquotedSrc = getBoundedString('src=', '>');
 
     function get(src, options) {
+        src = decode(src);
         src = dataProvider.toFullyQualifiedURL(src, options);
 
         return Promise.resolve()

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,10 +769,9 @@
       "dev": true
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hjs": {
       "version": "0.0.6",
@@ -1125,6 +1124,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
           "dev": true
         },
         "minimist": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "clone": "1.0.3",
-    "good-guy-http": "1.12.0"
+    "good-guy-http": "1.12.0",
+    "he": "1.2.0"
   },
   "devDependencies": {
     "coveralls": "3.0.2",

--- a/test/e2e-test.js
+++ b/test/e2e-test.js
@@ -65,6 +65,25 @@ describe('ESI processor', () => {
         }).catch(done);
     });
 
+    it('should fetch one external component with entities in URL', done => {
+        // given
+        server.addListener('request', (req, res) => {
+            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.end('<div>' + req.url + '</div>');
+        });
+
+        const html = "<section><esi:include src='http://localhost:" + port + "?foo=1&bar=2&amp;baz=3&#x00026;big=4&#38;bop=5'></esi:include></section>";
+
+        // when
+        const processed = ESI().process(html);
+
+        // then
+        processed.then(response => {
+            assert.equal(response, '<section><div>/?foo=1&bar=2&baz=3&big=4&bop=5</div></section>');
+            done();
+        }).catch(done);
+    });
+
     it('should fetch one external component with unquoted src', done => {
         // given
         server.addListener('request', (req, res) => {


### PR DESCRIPTION
fixes #17 

note: I'm making the `he` dependency explicit. `he` was already part of the dependency stack, so no new dependency has been added, but in order to guard against `good-guy-http` dropping the dependency, I've listed it in `package.json`.