### PR TITLE
feat(remove): <esi:remove> tags are not removed

### DIFF
--- a/lib/esi.js
+++ b/lib/esi.js
@@ -73,7 +73,6 @@ function ESI(config) {
     }
 
     function handleESIRemove(html) {
-        // check if placeholder is followed by an <esi:remove> tag
         const re = /<esi:remove>([\s\S]*?)<\/esi:remove>/gm;
         return html.replace(re, '');
     }

--- a/lib/esi.js
+++ b/lib/esi.js
@@ -23,6 +23,9 @@ function ESI(config) {
         const subtasks = [];
         const maxDepthReached = state.currentDepth > maxDepth;
 
+        // in current module, esi:remove are simply removed
+        html =  handleESIRemove(html);
+
         let i = 0;
         const tags = findESIIncludeTags(html, options);
         if (!tags.length) {
@@ -67,6 +70,12 @@ function ESI(config) {
             tags.push(match[0]);        
         }
         return tags;
+    }
+
+    function handleESIRemove(html) {
+        // check if placeholder is followed by an <esi:remove> tag
+        const re = /<esi:remove>([\s\S]*?)<\/esi:remove>/gm;
+        return html.replace(re, '');
     }
 
     function getIncludeContents(tag, options) {


### PR DESCRIPTION
PR for https://github.com/Schibsted-Tech-Polska/nodesi/issues/27

Completely removes the `esi:remove` tags from the DOM.

With this, I have the exact same behavior than on Fastly.