### PR TITLE
Allow esi tags with newlines in them

### DIFF
--- a/lib/esi.js
+++ b/lib/esi.js
@@ -59,11 +59,11 @@ function ESI(config) {
     }
 
     function hasESITag(html) {
-        return html.match(/<esi:include.*?(?:\/\s*>|<\/esi:include>)/gm)
+        return html.match(/<esi:include.*?(?:\/\s*>|<\/esi:include>)/gms)
     }
 
     function findESIIncludeTags(html) {        
-        const re = /<esi:include.*?(?:\/\s*>|<\/esi:include>)/gm;
+        const re = /<esi:include.*?(?:\/\s*>|<\/esi:include>)/gms;
         const tags = [];
         let match;
         while ((match = re.exec(html)) !== null) {
@@ -73,7 +73,7 @@ function ESI(config) {
     }
 
     function handleESIRemove(html) {
-        const re = /<esi:remove>([\s\S]*?)<\/esi:remove>/gm;
+        const re = /<esi:remove>([\s\S]*?)<\/esi:remove>/gms;
         return html.replace(re, '');
     }
 

--- a/test/e2e-test.js
+++ b/test/e2e-test.js
@@ -373,6 +373,33 @@ describe('ESI processor', () => {
             done();
         }).catch(done);
     });
+    
+    
+    it('should handle tags with newlines in them', done => {
+        // given
+        server.addListener('request', (req, res) => {
+            if (req.url === '/header') {
+                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.end('<section></section><div>something</div>');
+            } else {
+                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.end('not found');
+            }
+        });
+
+        const html = '<esi:include\nsrc="/header">\n</esi:include>';
+
+        // when
+        const processed = ESI({
+            baseUrl: 'http://localhost:' + port
+        }).process(html);
+
+        // then
+        processed.then(response => {
+            assert.equal(response, '<section></section><div>something</div>');
+            done();
+        }).catch(done);
+    });
 
     it('should gracefully degrade to empty content on error', done => {
         // given

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -82,7 +82,7 @@ describe('A express middleware', () => {
         }).catch(done);
     });
 
-    it.only('should fetch external component with a middleware when send is called (buffer version)', done => {
+    it('should fetch external component with a middleware when send is called (buffer version)', done => {
         // given
         server.addListener('request', (req, res) => {
             res.writeHead(200, {'Content-Type': 'text/html'});


### PR DESCRIPTION
This PR improves nodesi by allowing esi tags to have newlines in them like this:
```
              <esi:include
                src="..."
                onerror="continue"
              ></esi:include>
```
Regarding the change to the regex

From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions ): the `/s` modifier 

> Allows . to match newline characters. (Added in ES2018, not yet supported in Firefox).

Looking at compatibility tables, this seems to be working in node [since version 8.10](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll).

