### PR TITLE
Remove unused argument

### DIFF
--- a/lib/esi.js
+++ b/lib/esi.js
@@ -27,7 +27,7 @@ function ESI(config) {
         html =  handleESIRemove(html);
 
         let i = 0;
-        const tags = findESIIncludeTags(html, options);
+        const tags = findESIIncludeTags(html);
         if (!tags.length) {
             return Promise.resolve(html);
         }


### PR DESCRIPTION
`findESIIncludeTags` only uses the `html` argument, so it is safe not to call it with a second argument