### PR TITLE
Avoid replacement patters when using String.prototype.replace()

### DIFF
--- a/lib/esi.js
+++ b/lib/esi.js
@@ -39,7 +39,7 @@ function ESI(config) {
             } else if(tag.includes('<esi:include')) {
                 html = html.replace(tag, placeholder);
                 subtasks[i] = getIncludeContents(tag, options)
-                    .then(result => html = html.replace(placeholder, result));
+                    .then(result => html = html.replace(placeholder, () => result));
                 i++;
             }
         });


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter

In our case we had `$&` inside esi response of minified javascript, which is a replacement pattern in `String.prototype.replace()`. This leads to wrongly pasted esi-placeholders inside esi responses. By using a function we can avoid replacement patterns.