### PR TITLE
fix: invalid main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodesi",
   "version": "1.16.0",
   "description": "ESI: the good parts in node.js",
-  "main": "esi.js",
+  "main": "index.js",
   "scripts": {
     "test": "mocha test/*.js --exit",
     "test:debug": "mocha --inspect-brk test/*.js",


### PR DESCRIPTION
I was installing nodesi and saw the following warning from either node or yarn (unsure).

```
(node:180554) [DEP0128] DeprecationWarning: Invalid 'main' field in '/home/mclayton/projects/primer/node_modules/nodesi/package.json' of 'esi.js'. Please either fix that or report it to the module author
```

Looking at the repo, I'm not sure if `main` should point to the `index.js` at the root, or `lib/esi.js`, but index seemed like the safer bet.