### PR TITLE
Remove vulnerable libs and improve the code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.js]
+indent_style = space
+indent_size = 4
+quote_type = single

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ test
 .jshintrc
 .travis.yml
 .nvmrc
+.editorconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ deploy:
 
 after_success:
   - npm run coverage
-  - node_modules/.bin/nyc report --reporter=text-lcov | node_modules/.bin/coveralls

--- a/lib/data-provider.js
+++ b/lib/data-provider.js
@@ -1,9 +1,6 @@
 'use strict';
 
 const url = require('url');
-const defaultHeaders = {
-    Accept: 'text/html, application/xhtml+xml, application/xml',
-};
 
 module.exports = function DataProvider(config) {
     const pendingReqests = new Map();
@@ -12,6 +9,11 @@ module.exports = function DataProvider(config) {
 
     const baseUrl = config.baseUrl || '';
     const httpClient = config.httpClient || globalThis.fetch;
+    const userAgent = config.userAgent || 'node-esi';
+    const defaultHeaders = {
+        Accept: 'text/html, application/xhtml+xml, application/xml',
+        'user-agent': userAgent,
+    };
 
     function extendRequestOptions(src, baseOptions) {
         return [

--- a/lib/data-provider.js
+++ b/lib/data-provider.js
@@ -1,28 +1,30 @@
 'use strict';
 
-const goodGuyLib = require('good-guy-http');
 const url = require('url');
 const defaultHeaders = {
-    Accept: 'text/html, application/xhtml+xml, application/xml'
+    Accept: 'text/html, application/xhtml+xml, application/xml',
 };
 
 module.exports = function DataProvider(config) {
+    const pendingReqests = new Map();
+
     config = config || {};
 
     const baseUrl = config.baseUrl || '';
-    const goodGuy = config.httpClient || goodGuyLib({
-        cache: config.cache
-    });
+    const httpClient = config.httpClient || globalThis.fetch;
 
     function extendRequestOptions(src, baseOptions) {
-        return {
-            url: toFullyQualifiedURL(src, baseOptions),
-            headers: Object.assign({}, defaultHeaders, baseOptions.headers)
-        };
+        return [
+            toFullyQualifiedURL(src, baseOptions),
+            {
+                ...baseOptions,
+                headers: Object.assign({}, defaultHeaders, baseOptions.headers),
+            },
+        ];
     }
 
     function toFullyQualifiedURL(urlOrPath, baseOptions) {
-        if(urlOrPath.indexOf('http') === 0) {
+        if (urlOrPath.indexOf('http') === 0) {
             return urlOrPath;
         }
 
@@ -31,20 +33,36 @@ module.exports = function DataProvider(config) {
     }
 
     function get(src, baseOptions) {
-        const options = extendRequestOptions(src, baseOptions || {});
-        options.gzip = true; // For backwards-compatibility, response compression is not supported by default
+        const [resource, options] = extendRequestOptions(
+            src,
+            baseOptions || {}
+        );
 
-        return goodGuy.get(options)
-            .then(response => {
-                if(response.statusCode >= 400) {
-                    throw new Error(response.statusCode);
-                }
-                return {
-                    body: response.body,
-                    response: response
-                };
-            });
+        if (pendingReqests.has(resource)) {
+            return pendingReqests.get(resource);
+        }
+
+        pendingReqests.set(
+            resource,
+            httpClient(resource, options)
+                .then((response) => {
+                    if (response.status >= 400) {
+                        throw new Error(
+                            `HTTP error ${response.status}: ${response.statusText}`
+                        );
+                    }
+
+                    return response.text();
+                })
+                .then((text) => {
+                    pendingReqests.delete(resource);
+
+                    return text;
+                })
+        );
+
+        return pendingReqests.get(resource);
     }
 
-    return {toFullyQualifiedURL, get};
+    return { toFullyQualifiedURL, get };
 };

--- a/lib/esi.js
+++ b/lib/esi.js
@@ -122,7 +122,7 @@ function ESI(config) {
                 }
             })
             .then(() => dataProvider.get(src, options))
-            .then(result => result.body)
+            .then(result => result)
             .catch(error => alt ? get([alt], options) : handleError(src, error));
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,10 @@
       "version": "1.17.0",
       "license": "ISC",
       "dependencies": {
-        "good-guy-http": "1.14.0",
         "he": "1.2.0"
       },
       "devDependencies": {
         "autocannon": "^7.14.0",
-        "coveralls": "3.1.1",
         "express": "4.18.2",
         "hjs": "0.0.6",
         "mocha": "10.2.0",
@@ -660,11 +658,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@schibstedpl/circuit-breaker-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@schibstedpl/circuit-breaker-js/-/circuit-breaker-js-0.0.2.tgz",
-      "integrity": "sha512-82fEbDRVsEAO/XlaFsGb5GKoAMvlfOd/hiNxyPWMvd1ZYJxxHs8hAu4i5Jrlcgpf1sUhhgV53oJSHNwyThsVFQ=="
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -695,17 +688,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
-      "dependencies": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -793,26 +775,11 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "node_modules/autocannon": {
       "version": "7.14.0",
@@ -848,20 +815,6 @@
         "autocannon": "autocannon.js"
       }
     },
-    "node_modules/autocannon/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/autocannon/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -895,19 +848,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -933,15 +873,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1117,16 +1048,6 @@
         }
       ]
     },
-    "node_modules/capitalize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-1.0.0.tgz",
-      "integrity": "sha1-3IAsWAruEBkpAg0soUtMqKCuRL4="
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1223,15 +1144,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1263,6 +1175,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1324,135 +1237,6 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "node_modules/coveralls": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
-      "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
-      "dev": true,
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
-        "request": "^2.88.2"
-      },
-      "bin": {
-        "coveralls": "bin/coveralls.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/coveralls/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/coveralls/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "node_modules/coveralls/node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/coveralls/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/coveralls/node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/coveralls/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/coveralls/node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/coveralls/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/cross-argv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cross-argv/-/cross-argv-2.0.0.tgz",
@@ -1471,17 +1255,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/debug": {
@@ -1535,6 +1308,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1565,16 +1339,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ee-first": {
@@ -1703,29 +1467,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1811,25 +1552,18 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1941,14 +1675,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -2012,29 +1738,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/good-guy-http": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/good-guy-http/-/good-guy-http-1.14.0.tgz",
-      "integrity": "sha512-QkxYpypxMBVU+YRgbSckOoIi17a3/1JO1PXERHff1NpFdLrFNoAzn6CQ3xuYJ6veQtVMcVoLzxT8Zp0M6p0Jhg==",
-      "dependencies": {
-        "@schibstedpl/circuit-breaker-js": "0.0.2",
-        "capitalize": "^1.0.0",
-        "clone": "2.1.1",
-        "request": "2.87.0",
-        "underscore": "1.12.1"
-      },
-      "engines": {
-        "node": ">=5"
-      }
-    },
-    "node_modules/good-guy-http/node_modules/clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -2052,27 +1755,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha512-r7LZkP7Z6WMxj5zARzB9dSpIKu/sp0NfHIgtj6kmQXhEArNctjB5FEv/L2XfLdWqIocPT2QVt0LFOlEUioTBtQ==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/has-async-hooks": {
       "version": "1.0.0",
@@ -2231,20 +1913,6 @@
       "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
       "dev": true
     },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/hyperid": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.1.1.tgz",
@@ -2394,7 +2062,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -2422,11 +2091,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -2646,12 +2310,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -2664,21 +2322,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2689,29 +2332,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
-      "dev": true,
-      "bin": {
-        "lcov-parse": "bin/cli.js"
       }
     },
     "node_modules/locate-path": {
@@ -2752,15 +2372,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
-    },
-    "node_modules/log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.6"
-      }
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -2848,6 +2459,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2856,6 +2468,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3209,14 +2822,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -3370,11 +2975,6 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -3503,25 +3103,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -3585,37 +3166,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3665,6 +3215,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3683,7 +3234,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -3842,32 +3394,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "getpass": "^0.1.1",
-        "safer-buffer": "^2.0.2"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "optionalDependencies": {
-        "bcrypt-pbkdf": "^1.0.0",
-        "ecc-jsbn": "~0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -4023,34 +3549,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dependencies": {
-        "punycode": "^1.4.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
-    },
     "node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -4081,11 +3579,6 @@
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -4126,24 +3619,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -4151,15 +3626,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/uuid-parse": {
@@ -4175,19 +3641,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "good-guy-http": "1.14.0",
     "he": "1.2.0"
   },
   "devDependencies": {
     "autocannon": "^7.14.0",
-    "coveralls": "3.1.1",
     "express": "4.18.2",
     "hjs": "0.0.6",
     "mocha": "10.2.0",

--- a/test/e2e-test.js
+++ b/test/e2e-test.js
@@ -3,7 +3,6 @@
 const assert = require('assert');
 const http = require('http');
 const fs = require('fs');
-const goodGuyLib = require('good-guy-http');
 
 const ESI = require('../lib/esi');
 
@@ -23,257 +22,333 @@ describe('ESI processor', () => {
         server = null;
     });
 
-
-    it('should fetch one external component', done => {
+    it('should fetch one external component', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '"></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></esi:include></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch from fallback', done => {
+    it('should fetch from fallback', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/existing') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
-                res.end('<div>404</div>');        
+                res.writeHead(404, { 'Content-Type': 'text/html' });
+                res.end('<div>404</div>');
             }
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '/missing" alt="http://localhost:' + port + '/existing"></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '/missing" alt="http://localhost:' +
+            port +
+            '/existing"></esi:include></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should not fetch from fallback if src is ok', done => {
+    it('should not fetch from fallback if src is ok', (done) => {
         let invalidreq = false;
 
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/existing') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
             } else {
                 invalidreq = true;
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('<div>404</div>');
             }
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '/existing" alt="http://localhost:' + port + '/missing"></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '/existing" alt="http://localhost:' +
+            port +
+            '/missing"></esi:include></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
 
-        assert.equal(invalidreq, false, 'The fallback request should not have been made when the src request succeeded');
+        assert.equal(
+            invalidreq,
+            false,
+            'The fallback request should not have been made when the src request succeeded'
+        );
     });
 
-    it('should fetch one external component with single quoted src', done => {
+    it('should fetch one external component with single quoted src', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
 
-        const html = "<section><esi:include src='http://localhost:" + port + "'></esi:include></section>";
+        const html =
+            "<section><esi:include src='http://localhost:" +
+            port +
+            "'></esi:include></section>";
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch from fallback with single quoted alt', done => {
+    it('should fetch from fallback with single quoted alt', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/existing') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('<div>404</div>');
             }
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '/missing" alt=\'http://localhost:' + port + '/existing\'></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '/missing" alt=\'http://localhost:' +
+            port +
+            "/existing'></esi:include></section>";
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch one external component with entities in URL', done => {
+    it('should fetch one external component with entities in URL', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>' + req.url + '</div>');
         });
 
-        const html = "<section><esi:include src='http://localhost:" + port + "?foo=1&bar=2&amp;baz=3&#x00026;big=4&#38;bop=5'></esi:include></section>";
+        const html =
+            "<section><esi:include src='http://localhost:" +
+            port +
+            "?foo=1&bar=2&amp;baz=3&#x00026;big=4&#38;bop=5'></esi:include></section>";
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>/?foo=1&bar=2&baz=3&big=4&bop=5</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(
+                    response,
+                    '<section><div>/?foo=1&bar=2&baz=3&big=4&bop=5</div></section>'
+                );
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch one external component with unquoted src', done => {
+    it('should fetch one external component with unquoted src', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
 
-        const html = '<section><esi:include src=http://localhost:' + port + '></esi:include></section>';
+        const html =
+            '<section><esi:include src=http://localhost:' +
+            port +
+            '></esi:include></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch from fallback with unquoted alt', done => {
+    it('should fetch from fallback with unquoted alt', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/existing') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
-                res.end('<div>404</div>');    
+                res.writeHead(404, { 'Content-Type': 'text/html' });
+                res.end('<div>404</div>');
             }
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '/missing" alt=http://localhost:' + port + '/existing></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '/missing" alt=http://localhost:' +
+            port +
+            '/existing></esi:include></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch one self-closed external component', done => {
+    it('should fetch one self-closed external component', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '"/></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"/></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch nothing on typo', done => {
-        const html = '<section><esi:indclude src="http://localhost:' + port + '"/></section>';
+    it('should fetch nothing on typo', (done) => {
+        const html =
+            '<section><esi:indclude src="http://localhost:' +
+            port +
+            '"/></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, html);
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, html);
+                done();
+            })
+            .catch(done);
     });
 
-    it('should not process not properly closed tags', done => {
-        const html = '<section><esi:include src="http://localhost:' + port + '"></section>';
+    it('should not process not properly closed tags', (done) => {
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, html);
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, html);
+                done();
+            })
+            .catch(done);
     });
 
-
-    it('should handle self-closing tags in html', done => {
+    it('should handle self-closing tags in html', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '"></esi:include><img src="some-image" /></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></esi:include><img src="some-image" /></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div><img src="some-image" /></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(
+                    response,
+                    '<section><div>test</div><img src="some-image" /></section>'
+                );
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch one relative component', done => {
+    it('should fetch one relative component', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/header') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
@@ -282,25 +357,26 @@ describe('ESI processor', () => {
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<div>test</div>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<div>test</div>');
+                done();
+            })
+            .catch(done);
     });
 
-
-    it('should fetch one relative component (no leading slash)', done => {
+    it('should fetch one relative component (no leading slash)', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/header') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
@@ -309,54 +385,61 @@ describe('ESI processor', () => {
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<div>test</div>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<div>test</div>');
+                done();
+            })
+            .catch(done);
     });
 
-
-    it('should fetch multiple components', done => {
+    it('should fetch multiple components', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/header') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test header</div>');
             } else if (req.url === '/footer') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test footer</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
 
-        const html = '<esi:include src="/header"></esi:include><esi:include src="/footer"></esi:include>';
+        const html =
+            '<esi:include src="/header"></esi:include><esi:include src="/footer"></esi:include>';
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<div>test header</div><div>test footer</div>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(
+                    response,
+                    '<div>test header</div><div>test footer</div>'
+                );
+                done();
+            })
+            .catch(done);
     });
 
-    it('should handle immediately closed html tags', done => {
+    it('should handle immediately closed html tags', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/header') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<section></section><div>something</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
@@ -365,25 +448,29 @@ describe('ESI processor', () => {
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section></section><div>something</div>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(
+                    response,
+                    '<section></section><div>something</div>'
+                );
+                done();
+            })
+            .catch(done);
     });
-    
-    
-    it('should handle tags with newlines in them', done => {
+
+    it('should handle tags with newlines in them', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/header') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<section></section><div>something</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
@@ -392,20 +479,25 @@ describe('ESI processor', () => {
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section></section><div>something</div>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(
+                    response,
+                    '<section></section><div>something</div>'
+                );
+                done();
+            })
+            .catch(done);
     });
 
-    it('should gracefully degrade to empty content on error', done => {
+    it('should gracefully degrade to empty content on error', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(500, {'Content-Type': 'text/html'});
+            res.writeHead(500, { 'Content-Type': 'text/html' });
             res.end();
         });
 
@@ -413,21 +505,23 @@ describe('ESI processor', () => {
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should execute optional callback on error', done => {
+    it('should execute optional callback on error', (done) => {
         // given
         let assertionCount = 0;
         server.addListener('request', (req, res) => {
-            res.writeHead(500, {'Content-Type': 'text/html'});
+            res.writeHead(500, { 'Content-Type': 'text/html' });
             res.end();
         });
 
@@ -438,56 +532,68 @@ describe('ESI processor', () => {
             baseUrl: 'http://localhost:' + port,
             onError: (src, error) => {
                 assertionCount += 2;
-                assert.equal(error.message, 'HTTP error: status code 500');
+                assert.equal(
+                    error.message,
+                    'HTTP error 500: Internal Server Error'
+                );
                 assert.equal(src, 'http://localhost:' + port + '/error');
                 return '<div>something went wrong</div>';
-            }
+            },
         }).process(html);
 
         // then
-        processed.then(response => {
-            assertionCount++;
-            assert.equal(response, '<div>something went wrong</div>');
-            assert.equal(assertionCount, 3);
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assertionCount++;
+                assert.equal(response, '<div>something went wrong</div>');
+                assert.equal(assertionCount, 3);
+                done();
+            })
+            .catch(done);
     });
 
-    it('should gracefully degrade to empty content on timeout', done => {
+    it('should gracefully degrade to empty content on timeout', (done) => {
         // given
         server.addListener('request', (req, res) => {
             setTimeout(() => {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('this should not happen');
             }, 10);
         });
 
         const html = '<esi:include src="/error"></esi:include>';
+        const abortController = new AbortController();
 
         // when
         const processed = ESI({
             baseUrl: 'http://localhost:' + port,
-            httpClient: goodGuyLib({
-                timeout: 1
-            })
-        }).process(html);
+            httpClient: (url, options) =>
+                fetch(url, { ...options, signal: abortController.signal }),
+        })
+            .process(html)
+            .catch((err) => {
+                console.log('test catch', err);
+            });
+
+        abortController.abort();
 
         // then
-        processed.then(response => {
-            assert.equal(response, '');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should allow to disable cache', done => {
+    it('should allow to disable cache', (done) => {
         // given
         let connectionCount = 0;
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
-            if(connectionCount === 0) {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            if (connectionCount === 0) {
                 res.end('hello');
-            }
-            else {
+            } else {
                 res.end('world');
             }
             connectionCount++;
@@ -498,206 +604,246 @@ describe('ESI processor', () => {
         // when
         const esi = ESI({
             baseUrl: 'http://localhost:' + port,
-            cache: false
+            cache: false,
         });
 
         const processed = esi.process(html);
 
         // then
-        processed.then(response => {
-            return esi.process(html);
-        }).then(response => {
-            assert.equal(response, 'world');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                return esi.process(html);
+            })
+            .then((response) => {
+                assert.equal(response, 'world');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch components recursively', done => {
+    it('should fetch components recursively', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             if (req.url === '/first') {
-                res.end('<esi:include src="http://localhost:' + port + '/second"></esi:include>');
+                res.end(
+                    '<esi:include src="http://localhost:' +
+                        port +
+                        '/second"></esi:include>'
+                );
             } else if (req.url === '/second') {
-                res.end('<esi:include src="http://localhost:' + port + '/third"></esi:include>');
+                res.end(
+                    '<esi:include src="http://localhost:' +
+                        port +
+                        '/third"></esi:include>'
+                );
             } else {
                 res.end('<div>test</div>');
             }
-
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '/first"></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '/first"></esi:include></section>';
 
         // when
         const processed = ESI().process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should set max fetch limit for recursive components', done => {
-       // given
-       server.addListener('request', (req, res) => {
-           res.writeHead(200, {'Content-Type': 'text/html'});
-           res.end('<esi:include src="http://localhost:' + port + '"></esi:include>');
-       });
-    
-       const html = '<section><esi:include src="http://localhost:' + port + '"></esi:include></section>';
-    
-       // when
-       const processed = ESI({
-           maxDepth: 5
-       }).process(html);
-    
-       // then
-       processed.then(response => {
-           assert.equal(response, '<section></section>');
-           done();
-       }).catch(done);
+    it('should set max fetch limit for recursive components', (done) => {
+        // given
+        server.addListener('request', (req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end(
+                '<esi:include src="http://localhost:' +
+                    port +
+                    '"></esi:include>'
+            );
+        });
+
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></esi:include></section>';
+
+        // when
+        const processed = ESI({
+            maxDepth: 5,
+        }).process(html);
+
+        // then
+        processed
+            .then((response) => {
+                assert.equal(response, '<section></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should pass specified headers to server', done => {
+    it('should pass specified headers to server', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.headers['x-custom-header']) {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
-            }
-            else {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+            } else {
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('you should not get this');
             }
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '"></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></esi:include></section>';
 
         // when
         const processed = ESI().process(html, {
             headers: {
-                'x-custom-header': 'blah'
-            }
+                'x-custom-header': 'blah',
+            },
         });
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should throw appropriate error if the host was blocked', done => {
+    it('should throw appropriate error if the host was blocked', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '"></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></esi:include></section>';
 
-        const esi  = ESI({
+        const esi = ESI({
             allowedHosts: ['http://not-localhost'],
             onError: (src, err) => {
                 // then
                 assert.equal(src, 'http://localhost:' + port);
                 assert.ok(err.blocked);
-                assert.ok(err.message.includes('is not included in allowedHosts'));
+                assert.ok(
+                    err.message.includes('is not included in allowedHosts')
+                );
                 done();
-            }
+            },
+        });
+
+        // when
+        esi.process(html).catch(done);
+    });
+
+    it('should support regular expressions in the configured allowedHosts', (done) => {
+        // given
+        server.addListener('request', (req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end('<div>test</div>');
+        });
+
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></esi:include></section>';
+
+        const errors = [];
+        const esi = ESI({
+            allowedHosts: [/http:\/\/.*/],
+            onError: (src, err) => {
+                errors.push(err);
+            },
         });
 
         // when
         esi.process(html)
+            .then((res) => {
+                // then
+                assert.equal(errors.length, 0);
+                assert.equal(res, '<section><div>test</div></section>');
+                done();
+            })
             .catch(done);
     });
 
-    it('should support regular expressions in the configured allowedHosts', done => {
+    it('should support custom implementation of allowedHosts', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
 
-        const html = '<section><esi:include src="http://localhost:' + port + '"></esi:include></section>';
+        const html =
+            '<section><esi:include src="http://localhost:' +
+            port +
+            '"></esi:include></section>';
 
         const errors = [];
-        const esi  = ESI({
-            allowedHosts: [/http:\/\/.*/],
-            onError: (src, err) => {
-                errors.push(err);
-            }
-        });
-
-        // when
-        esi.process(html).then(res => {
-
-            // then
-            assert.equal(errors.length, 0);
-            assert.equal(res, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
-    });
-
-    it('should support custom implementation of allowedHosts', done => {
-        // given
-        server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
-            res.end('<div>test</div>');
-        });
-
-        const html = '<section><esi:include src="http://localhost:' + port + '"></esi:include></section>';
-
-        const errors = [];
-        const esi  = ESI({
+        const esi = ESI({
             baseUrl: 'http://localhost:' + port,
             allowedHosts: {
                 includes() {
                     return false;
-                }
+                },
             },
             onError: (src, err) => {
                 errors.push(err);
-            }
+            },
         });
 
         // when
-        esi.process(html).then(res => {
-
-            // then
-            assert.equal(errors.length, 1);
-            assert.ok(errors[0].blocked);
-            assert.equal(res, '<section></section>');
-            done();
-        }).catch(done);
+        esi.process(html)
+            .then((res) => {
+                // then
+                assert.equal(errors.length, 1);
+                assert.ok(errors[0].blocked);
+                assert.equal(res, '<section></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should be able to use custom log output', done => {
+    it('should be able to use custom log output', (done) => {
         // given
-        const esi  = ESI({
+        const esi = ESI({
             allowedHosts: ['http://localhost'],
             logTo: {
-                write: log => {
+                write: (log) => {
                     // then
                     assert.equal(log, 'test');
                     done();
-                }
-            }
+                },
+            },
         });
 
         // when
         esi.logger.write('test');
     });
 
-    it('should be able to log output to a file', done => {
+    it('should be able to log output to a file', (done) => {
         // given
         const PATH = './test/logger-test-output.txt';
         const stream = fs.createWriteStream(PATH);
         const testStr = '' + Math.random();
-        const esi  = ESI({
+        const esi = ESI({
             allowedHosts: ['http://localhost'],
-            logTo: stream
+            logTo: stream,
         });
 
         // when
@@ -706,13 +852,13 @@ describe('ESI processor', () => {
         // then
         stream.on('finish', () => {
             fs.readFile(PATH, (err, contents) => {
-                if(err) {
+                if (err) {
                     done(err);
                 } else {
                     assert.equal(contents.toString(), testStr);
                     fs.unlink(PATH, done);
                 }
-            });    
+            });
         });
         stream.close();
     });
@@ -727,116 +873,135 @@ describe('ESI processor', () => {
 
         assert.equal(tags.length, 2);
         assert.deepEqual(tags, [
-            `<esi:include src="/nav.html"></esi:include>`, 
-            `<esi:include src='/main.html'/>`]);
+            `<esi:include src="/nav.html"></esi:include>`,
+            `<esi:include src='/main.html'/>`,
+        ]);
     });
 
-    it('should remove standard <esi:remove> usage', done => {
+    it('should remove standard <esi:remove> usage', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/main') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>main</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
 
-        const html = '<section><esi:include src="/main"></esi:include><esi:remove><a href="#">Fallback link</a></esi:remove></section>';
+        const html =
+            '<section><esi:include src="/main"></esi:include><esi:remove><a href="#">Fallback link</a></esi:remove></section>';
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section><div>main</div></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section><div>main</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should remove any <esi:remove>', done => {
+    it('should remove any <esi:remove>', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/main') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>main</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
 
-        const html = '<section><esi:remove><a href="#">Fallback link</a></esi:remove></section>';
+        const html =
+            '<section><esi:remove><a href="#">Fallback link</a></esi:remove></section>';
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section></section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(response, '<section></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should handle line-breaks and indent in <esi:remove>', done => {
+    it('should handle line-breaks and indent in <esi:remove>', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/main') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>main</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
 
-        const html = '<section>\n  <esi:include src="/main"></esi:include>\n  <esi:remove>\n    <a href="#">Fallback link</a>\n  </esi:remove>\n  </section>';
+        const html =
+            '<section>\n  <esi:include src="/main"></esi:include>\n  <esi:remove>\n    <a href="#">Fallback link</a>\n  </esi:remove>\n  </section>';
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<section>\n  <div>main</div>\n  \n  </section>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(
+                    response,
+                    '<section>\n  <div>main</div>\n  \n  </section>'
+                );
+                done();
+            })
+            .catch(done);
     });
 
-    it('should remove multiple <esi:remove>', done => {
+    it('should remove multiple <esi:remove>', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/header') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>header</div>');
             } else if (req.url === '/footer') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>footer</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
 
-        const html = '<header><esi:include src="/header"></esi:include><esi:remove><a href="#">Fallback header</a></esi:remove></header>\
+        const html =
+            '<header><esi:include src="/header"></esi:include><esi:remove><a href="#">Fallback header</a></esi:remove></header>\
 <section>some main content</section>\
 <footer><esi:include src="/footer"></esi:include><esi:remove><a href="#">Fallback footer</a></esi:remove></footer>';
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port
+            baseUrl: 'http://localhost:' + port,
         }).process(html);
 
         // then
-        processed.then(response => {
-            assert.equal(response, '<header><div>header</div></header><section>some main content</section><footer><div>footer</div></footer>');
-            done();
-        }).catch(done);
+        processed
+            .then((response) => {
+                assert.equal(
+                    response,
+                    '<header><div>header</div></header><section>some main content</section><footer><div>footer</div></footer>'
+                );
+                done();
+            })
+            .catch(done);
     });
 });

--- a/test/e2e-test.js
+++ b/test/e2e-test.js
@@ -29,10 +29,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -58,12 +55,7 @@ describe('ESI processor', () => {
             }
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '/missing" alt="http://localhost:' +
-            port +
-            '/existing"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}/missing" alt="http://localhost:${port}/existing"></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -92,12 +84,7 @@ describe('ESI processor', () => {
             }
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '/existing" alt="http://localhost:' +
-            port +
-            '/missing"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}/existing" alt="http://localhost:${port}/missing"></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -124,10 +111,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            "<section><esi:include src='http://localhost:" +
-            port +
-            "'></esi:include></section>";
+        const html = `<section><esi:include src='http://localhost:${port}'></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -153,12 +137,7 @@ describe('ESI processor', () => {
             }
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '/missing" alt=\'http://localhost:' +
-            port +
-            "/existing'></esi:include></section>";
+        const html = `<section><esi:include src="http://localhost:${port}/missing" alt=\'http://localhost:${port}/existing'></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -176,13 +155,10 @@ describe('ESI processor', () => {
         // given
         server.addListener('request', (req, res) => {
             res.writeHead(200, { 'Content-Type': 'text/html' });
-            res.end('<div>' + req.url + '</div>');
+            res.end(`<div>${req.url}</div>`);
         });
 
-        const html =
-            "<section><esi:include src='http://localhost:" +
-            port +
-            "?foo=1&bar=2&amp;baz=3&#x00026;big=4&#38;bop=5'></esi:include></section>";
+        const html = `<section><esi:include src='http://localhost:${port}?foo=1&bar=2&amp;baz=3&#x00026;big=4&#38;bop=5'></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -206,10 +182,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            '<section><esi:include src=http://localhost:' +
-            port +
-            '></esi:include></section>';
+        const html = `<section><esi:include src=http://localhost:${port}></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -235,12 +208,7 @@ describe('ESI processor', () => {
             }
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '/missing" alt=http://localhost:' +
-            port +
-            '/existing></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}/missing" alt=http://localhost:${port}/existing></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -261,10 +229,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"/></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"/></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -279,10 +244,7 @@ describe('ESI processor', () => {
     });
 
     it('should fetch nothing on typo', (done) => {
-        const html =
-            '<section><esi:indclude src="http://localhost:' +
-            port +
-            '"/></section>';
+        const html = `<section><esi:indclude src="http://localhost:${port}"/></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -297,10 +259,7 @@ describe('ESI processor', () => {
     });
 
     it('should not process not properly closed tags', (done) => {
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -321,10 +280,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></esi:include><img src="some-image" /></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include><img src="some-image" /></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -536,7 +492,7 @@ describe('ESI processor', () => {
                     error.message,
                     'HTTP error 500: Internal Server Error'
                 );
-                assert.equal(src, 'http://localhost:' + port + '/error');
+                assert.equal(src, `http://localhost:${port}/error`);
                 return '<div>something went wrong</div>';
             },
         }).process(html);
@@ -586,66 +542,24 @@ describe('ESI processor', () => {
             .catch(done);
     });
 
-    it('should allow to disable cache', (done) => {
-        // given
-        let connectionCount = 0;
-        server.addListener('request', (req, res) => {
-            res.writeHead(200, { 'Content-Type': 'text/html' });
-            if (connectionCount === 0) {
-                res.end('hello');
-            } else {
-                res.end('world');
-            }
-            connectionCount++;
-        });
-
-        const html = '<esi:include src="/cacheme"></esi:include>';
-
-        // when
-        const esi = ESI({
-            baseUrl: 'http://localhost:' + port,
-            cache: false,
-        });
-
-        const processed = esi.process(html);
-
-        // then
-        processed
-            .then((response) => {
-                return esi.process(html);
-            })
-            .then((response) => {
-                assert.equal(response, 'world');
-                done();
-            })
-            .catch(done);
-    });
-
     it('should fetch components recursively', (done) => {
         // given
         server.addListener('request', (req, res) => {
             res.writeHead(200, { 'Content-Type': 'text/html' });
             if (req.url === '/first') {
                 res.end(
-                    '<esi:include src="http://localhost:' +
-                        port +
-                        '/second"></esi:include>'
+                    `<esi:include src="http://localhost:${port}/second"></esi:include>`
                 );
             } else if (req.url === '/second') {
                 res.end(
-                    '<esi:include src="http://localhost:' +
-                        port +
-                        '/third"></esi:include>'
+                    `<esi:include src="http://localhost:${port}/third"></esi:include>`
                 );
             } else {
                 res.end('<div>test</div>');
             }
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '/first"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}/first"></esi:include></section>`;
 
         // when
         const processed = ESI().process(html);
@@ -664,16 +578,11 @@ describe('ESI processor', () => {
         server.addListener('request', (req, res) => {
             res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end(
-                '<esi:include src="http://localhost:' +
-                    port +
-                    '"></esi:include>'
+                `<esi:include src="http://localhost:${port}"></esi:include>`
             );
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
 
         // when
         const processed = ESI({
@@ -701,10 +610,7 @@ describe('ESI processor', () => {
             }
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
 
         // when
         const processed = ESI().process(html, {
@@ -722,6 +628,49 @@ describe('ESI processor', () => {
             .catch(done);
     });
 
+    it('should pass a default user-agent header to the server', (done) => {
+        // given
+        server.addListener('request', (req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end(req.headers['user-agent']);
+        });
+
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
+
+        // when
+        const processed = ESI().process(html);
+
+        // then
+        processed
+            .then((response) => {
+                assert.equal(response, '<section>node-esi</section>');
+                done();
+            })
+            .catch(done);
+    });
+
+    it('should pass a custom user-agent header to the server', (done) => {
+        // given
+        const userAgent = 'my-custom-agent';
+        server.addListener('request', (req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end(req.headers['user-agent']);
+        });
+
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
+
+        // when
+        const processed = ESI({ userAgent }).process(html);
+
+        // then
+        processed
+            .then((response) => {
+                assert.equal(response, `<section>${userAgent}</section>`);
+                done();
+            })
+            .catch(done);
+    });
+
     it('should throw appropriate error if the host was blocked', (done) => {
         // given
         server.addListener('request', (req, res) => {
@@ -729,10 +678,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
 
         const esi = ESI({
             allowedHosts: ['http://not-localhost'],
@@ -758,10 +704,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
 
         const errors = [];
         const esi = ESI({
@@ -789,10 +732,7 @@ describe('ESI processor', () => {
             res.end('<div>test</div>');
         });
 
-        const html =
-            '<section><esi:include src="http://localhost:' +
-            port +
-            '"></esi:include></section>';
+        const html = `<section><esi:include src="http://localhost:${port}"></esi:include></section>`;
 
         const errors = [];
         const esi = ESI({
@@ -990,7 +930,7 @@ describe('ESI processor', () => {
 
         // when
         const processed = ESI({
-            baseUrl: 'http://localhost:' + port,
+            baseUrl: `http://localhost:${port}`,
         }).process(html);
 
         // then

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -2,14 +2,10 @@
 
 const assert = require('assert');
 const http = require('http');
-const goodGuy = require('good-guy-http');
 const middleware = require('../lib/middleware');
 const createExpressApp = require('./express-app');
 
-
 describe('A express middleware', () => {
-
-    let gg = null;
     let app = null;
     let server = null;
     let expressServer = null;
@@ -18,7 +14,6 @@ describe('A express middleware', () => {
 
     // setup express app, listening server and update port
     beforeEach(() => {
-        gg = goodGuy();
         app = createExpressApp();
         expressServer = app.listen();
         expressPort = expressServer.address().port;
@@ -29,7 +24,6 @@ describe('A express middleware', () => {
     });
 
     afterEach(() => {
-        gg = null;
         expressServer.close();
         expressServer = null;
 
@@ -37,77 +31,92 @@ describe('A express middleware', () => {
         server = null;
     });
 
-    it('should fetch external component with a middleware when render is called', done => {
+    it('should fetch external component with a middleware when render is called', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
         app.use(middleware());
         app.get('/esi', (req, res) => {
             res.render('single-external-component', {
-                port: port
+                port: port,
             });
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/esi');
+        const req = fetch('http://localhost:' + expressPort + '/esi');
 
         // then
-        req.then(response => {
-            assert.equal(response.body, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-
-    it('should fetch external component with a middleware when send is called', done => {
+    it('should fetch external component with a middleware when send is called', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
         app.use(middleware());
         app.get('/esi', (req, res) => {
-            res.send('<section><esi:include src="http://localhost:' + port + '"></esi:include></section>');
+            res.send(
+                '<section><esi:include src="http://localhost:' +
+                    port +
+                    '"></esi:include></section>'
+            );
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/esi');
+        const req = fetch('http://localhost:' + expressPort + '/esi');
 
         // then
-        req.then(response => {
-            assert.equal(response.body, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should fetch external component with a middleware when send is called (buffer version)', done => {
+    it('should fetch external component with a middleware when send is called (buffer version)', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
         app.use(middleware());
         app.get('/esi', (req, res) => {
             res.type('text/html');
-            res.send(Buffer.from('<section><esi:include src="http://localhost:' + port + '"></esi:include></section>'));
+            res.send(
+                Buffer.from(
+                    '<section><esi:include src="http://localhost:' +
+                        port +
+                        '"></esi:include></section>'
+                )
+            );
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/esi');
+        const req = fetch('http://localhost:' + expressPort + '/esi');
 
         // then
-        req.then(response => {
-            assert.equal(response.body, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should respect user defined callback in second parameter', done => {
+    it('should respect user defined callback in second parameter', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
         app.use(middleware());
@@ -119,155 +128,181 @@ describe('A express middleware', () => {
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/esi');
+        const req = fetch('http://localhost:' + expressPort + '/esi');
 
         // then
-        req.then(response => {
-            assert.equal(response.body, '<section><div>test</div></section>');
-            done();
-        }).catch(done);
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, '<section><div>test</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should respect user defined callback in third parameter', done => {
+    it('should respect user defined callback in third parameter', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
+            res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end('<div>test</div>');
         });
         app.use(middleware());
         app.get('/esi', (req, res) => {
-            res.render('single-external-component', {
-                port: port
-            }, (err, str) => {
-                str = str.replace('test', 'teststuff');
-                res.send(str);
-            });
+            res.render(
+                'single-external-component',
+                {
+                    port: port,
+                },
+                (err, str) => {
+                    str = str.replace('test', 'teststuff');
+                    res.send(str);
+                }
+            );
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/esi');
+        const req = fetch('http://localhost:' + expressPort + '/esi');
 
         // then
-        req.then(response => {
-            assert.equal(response.body, '<section><div>teststuff</div></section>');
-            done();
-        }).catch(done);
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, '<section><div>teststuff</div></section>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should be configurable', done => {
+    it('should be configurable', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.url === '/header') {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
             } else {
-                res.writeHead(404, {'Content-Type': 'text/html'});
+                res.writeHead(404, { 'Content-Type': 'text/html' });
                 res.end('not found');
             }
         });
-        app.use(middleware({
-            baseUrl: 'http://localhost:' + port
-        }));
+        app.use(
+            middleware({
+                baseUrl: 'http://localhost:' + port,
+            })
+        );
         app.get('/esi', (req, res) => {
             res.render('single-external-component-relative');
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/esi');
+        const req = fetch('http://localhost:' + expressPort + '/esi');
 
         // then
-        req.then(response => {
-            assert.equal(response.body, '<div>test</div>');
-            done();
-        }).catch(done);
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, '<div>test</div>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should pass headers', done => {
+    it('should pass headers', (done) => {
         // given
         server.addListener('request', (req, res) => {
             if (req.headers['x-custom-header']) {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('<div>test</div>');
-            }
-            else {
-                res.writeHead(200, {'Content-Type': 'text/html'});
+            } else {
+                res.writeHead(200, { 'Content-Type': 'text/html' });
                 res.end('you should not get this');
             }
         });
-        app.use(middleware({
-            baseUrl: 'http://localhost:' + port
-        }));
+        app.use(
+            middleware({
+                baseUrl: 'http://localhost:' + port,
+            })
+        );
         app.get('/esi', (req, res) => {
             req.esiOptions = {
                 headers: {
-                    'x-custom-header': 'blah'
-                }
+                    'x-custom-header': 'blah',
+                },
             };
             res.render('single-external-component-relative');
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/esi');
+        const req = fetch('http://localhost:' + expressPort + '/esi');
 
         // then
-        req.then(response => {
-            assert.equal(response.body, '<div>test</div>');
-            done();
-        }).catch(done);
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, '<div>test</div>');
+                done();
+            })
+            .catch(done);
     });
 
-    it('should use request baseUrl headers', done => {
+    it('should use request baseUrl headers', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
-            res.end('I\'m included via ' + req.url);
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end("I'm included via " + req.url);
         });
         const baseUrl = 'http://localhost:' + port;
-        app.use(middleware({
-            baseUrl
-        }));
+        app.use(
+            middleware({
+                baseUrl,
+            })
+        );
         app.get('*', (req, res) => {
             req.esiOptions = {
-                baseUrl: baseUrl + req.url
+                baseUrl: baseUrl + req.url,
             };
             res.render('single-external-component-template-relative');
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/foo/bar/index.html');
+        const req = fetch(
+            'http://localhost:' + expressPort + '/foo/bar/index.html'
+        );
 
         // then
-        req.then(response => {
-            assert.equal(response.body, 'I\'m included via /foo/bar/header.html');
-            done();
-        }).catch(done);
-    })
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, "I'm included via /foo/bar/header.html");
+                done();
+            })
+            .catch(done);
+    });
 
-    it('should use request baseUrl headers in send', done => {
+    it('should use request baseUrl headers in send', (done) => {
         // given
         server.addListener('request', (req, res) => {
-            res.writeHead(200, {'Content-Type': 'text/html'});
-            res.end('I\'m included via ' + req.url);
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end("I'm included via " + req.url);
         });
         const baseUrl = 'http://localhost:' + port;
-        app.use(middleware({
-            baseUrl
-        }));
+        app.use(
+            middleware({
+                baseUrl,
+            })
+        );
         app.get('*', (req, res) => {
             req.esiOptions = {
-                baseUrl: baseUrl + req.url
+                baseUrl: baseUrl + req.url,
             };
             res.send('<esi:include src="header.html"></esi:include>');
         });
 
         // when
-        const req = gg.get('http://localhost:' + expressPort + '/foo/bar/index.html');
+        const req = fetch(
+            'http://localhost:' + expressPort + '/foo/bar/index.html'
+        );
 
         // then
-        req.then(response => {
-            assert.equal(response.body, 'I\'m included via /foo/bar/header.html');
-            done();
-        }).catch(done);
-    })
-
+        req.then((response) => response.text())
+            .then((text) => {
+                assert.equal(text, "I'm included via /foo/bar/header.html");
+                done();
+            })
+            .catch(done);
+    });
 });


### PR DESCRIPTION
* **feat: remove vulnerable libs**

    ```
    This requires a change of the http request lib. Now nodesi uses
    a native fetch, or you can provide your own http client
    implementation.
    
    Previously nodesi used good-guy-http, which is no longer
    maintained, so the change in the behavior is that nodesi
    does not provide a cache out of the box.
    
    good-guy-http came with the in-memory cache that respected
    Cache-Control headers, but the new native fetch implementation
    does not provide this feature.
    
    BREAKING CHANGE: change in the default http request library
    ```

* **feat: add abitlity to pass the user-agent in config object**