### PR TITLE
fix: do not persist rejections

### DIFF
--- a/lib/data-provider.js
+++ b/lib/data-provider.js
@@ -56,7 +56,7 @@ module.exports = function DataProvider(config) {
 
                     return response.text();
                 })
-                .then((text) => {
+                .finally((text) => {
                     pendingReqests.delete(resource);
 
                     return text;


### PR DESCRIPTION
if a fetch promise rejected for some reason,
the resource cache was not cleared, so every
consecutive request was failing.